### PR TITLE
adding childProcess.fork [options]

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,9 @@ methods = {
         z.emit('worker-aborted',worker);
         return;
       }
-      var cp = fork(worker,args);
+      //worker.options= {options: {execArgv: ["--debug-brk=56000"]}}; 
+      //worker.add.call(worker, "worker.js", 1);
+      var cp = fork(worker,args, z.options);
 
       z.workers[worker].process.push(cp);
 


### PR DESCRIPTION
usefull to add execArgv's when debugging
doc https://nodejs.org/dist/latest-v4.x/docs/api/child_process.html#child_process_child_process_fork_modulepath_args_options
